### PR TITLE
gh-action updated: publish only dist folder

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -113,7 +113,7 @@ jobs:
         run: cp package-lock.json dist/
         
       - name: Publish package
-        working-directory: ${{ matrix.package }}
+        working-directory: ${{ matrix.package }}/dist
         run: npm publish --access restricted
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the GitHub Actions workflow to publish packages from the correct `dist` subdirectory, ensuring proper packaging and deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->